### PR TITLE
Add two-way SMS responses

### DIFF
--- a/healthzed/endpoint.py
+++ b/healthzed/endpoint.py
@@ -4,6 +4,14 @@ import uvicorn
 
 from healthzed.protocol import PingRequest, PingResponse
 
+import asyncio
+import logging.config
+
+logging.config.fileConfig("logging.conf")
+
+# create logger
+logger = logging.getLogger(__name__)
+
 app = FastAPI()
 
 
@@ -13,13 +21,14 @@ def check_health():
 
 
 @app.post("/send_ping")
-def send_ping(data: PingRequest):
-    response = deliver_ping(
-        message=data.message,
-        phone_number=data.phone_number,
+async def send_ping(data: PingRequest):
+    send_task = asyncio.create_task(
+        deliver_ping(message=data.message, phone_number=data.phone_number)
     )
-    if response:
-        return PingResponse(status_code=200, message="Ping sent successfully!")
+
+    await send_task
+
+    return PingResponse(status_code=200, message="Ping sent successfully!")
 
 
 if __name__ == "__main__":

--- a/healthzed/endpoint.py
+++ b/healthzed/endpoint.py
@@ -15,8 +15,6 @@ def check_health():
 @app.post("/send_ping")
 def send_ping(data: PingRequest):
     response = deliver_ping(
-        from_user=data.from_user,
-        to_user=data.to_user,
         message=data.message,
         phone_number=data.phone_number,
     )

--- a/healthzed/main.py
+++ b/healthzed/main.py
@@ -10,8 +10,8 @@ from healthzed.notification_service import NotificationService
 notification_service = NotificationService()
 
 
-def deliver_ping(message: str, phone_number: str):
-    logger.info(f"delivering ping to phone number {phone_number}...")
+async def deliver_ping(message: str, phone_number: str):
+    logger.info(f"asynchronously delivering ping to phone number {phone_number}...")
     notification_service.send_sns_notification(
         phone_number=phone_number, message=message
     )

--- a/healthzed/main.py
+++ b/healthzed/main.py
@@ -12,9 +12,6 @@ notification_service = NotificationService()
 
 async def deliver_ping(message: str, phone_number: str):
     logger.info(f"asynchronously delivering ping to phone number {phone_number}...")
-    # notification_service.send_sns_notification(
-    #     phone_number=phone_number, message=message
-    # )
     notification_service.send_pinpoint_sms_notification(
         destination_number=phone_number,
         message=message,

--- a/healthzed/main.py
+++ b/healthzed/main.py
@@ -12,7 +12,11 @@ notification_service = NotificationService()
 
 async def deliver_ping(message: str, phone_number: str):
     logger.info(f"asynchronously delivering ping to phone number {phone_number}...")
-    notification_service.send_sns_notification(
-        phone_number=phone_number, message=message
+    # notification_service.send_sns_notification(
+    #     phone_number=phone_number, message=message
+    # )
+    notification_service.send_pinpoint_sms_notification(
+        destination_number=phone_number,
+        message=message,
     )
     return True

--- a/healthzed/notification_service.py
+++ b/healthzed/notification_service.py
@@ -15,35 +15,12 @@ logger = logging.getLogger(__name__)
 
 class NotificationService:
     def __init__(self):
-        # Using a boto3 client to publish using a phone_number
-        # otherwise there would be an ARN conflict
-        self.sns_client = boto3.client(
-            "sns",
-            aws_access_key_id=os.environ["AWS_ACCESS_KEY"],
-            aws_secret_access_key=os.environ["AWS_SECRET_KEY"],
-            region_name=os.environ["AWS_REGION"],
-        )
         self.pinpoint_client = boto3.client(
             "pinpoint",
             aws_access_key_id=os.environ["AWS_ACCESS_KEY"],
             aws_secret_access_key=os.environ["AWS_SECRET_KEY"],
             region_name=os.environ["AWS_PINPOINT_REGION"],
         )
-
-    def send_sns_notification(self, phone_number, message="Test SNS message!"):
-        try:
-            response = self.sns_client.publish(
-                PhoneNumber=phone_number, Message=message
-            )
-            message_id = response["MessageId"]
-            logger.info(f"Published message to phone number {phone_number}")
-        except ClientError:
-            logger.exception(
-                f"Couldn't publish message to phone number {phone_number}."
-            )
-            raise
-        else:
-            return message_id
 
     def send_pinpoint_sms_notification(
         self,

--- a/healthzed/notification_service.py
+++ b/healthzed/notification_service.py
@@ -23,6 +23,12 @@ class NotificationService:
             aws_secret_access_key=os.environ["AWS_SECRET_KEY"],
             region_name=os.environ["AWS_REGION"],
         )
+        self.pinpoint_client = boto3.client(
+            "pinpoint",
+            aws_access_key_id=os.environ["AWS_ACCESS_KEY"],
+            aws_secret_access_key=os.environ["AWS_SECRET_KEY"],
+            region_name=os.environ["AWS_PINPOINT_REGION"],
+        )
 
     def send_sns_notification(self, phone_number, message="Test SNS message!"):
         try:
@@ -38,3 +44,33 @@ class NotificationService:
             raise
         else:
             return message_id
+
+    def send_pinpoint_sms_notification(
+        self,
+        destination_number,
+        message,
+        message_type="PROMOTIONAL",
+        origination_number="+18078085477",
+        app_id="8bd98417d59a452f96fcc2b60cbd13cf",
+    ):
+        try:
+            response = self.pinpoint_client.send_messages(
+                ApplicationId=app_id,
+                MessageRequest={
+                    "Addresses": {destination_number: {"ChannelType": "SMS"}},
+                    "MessageConfiguration": {
+                        "SMSMessage": {
+                            "Body": message,
+                            "MessageType": message_type,
+                            "OriginationNumber": origination_number,
+                        }
+                    },
+                },
+            )
+        except ClientError:
+            logger.exception("Couldn't send message.")
+            raise
+        else:
+            return response["MessageResponse"]["Result"][destination_number][
+                "MessageId"
+            ]


### PR DESCRIPTION
AC: 

In this PR, I will: 
~~1. make sending messages through AWS SNS an async method, so that it will be easier to await for the response, and~~
2. allow the users to respond to the texts, completing the "feedback" loop. 

For point 2, I will be using AWS Pinpoint as outlined in [this guide](https://medium.com/tensult/how-to-receive-messages-using-aws-pinpoint-ee0c6f9115bd). This requires getting an AWS Pinpoint SMS long code, which I'm waiting on support to provide. 